### PR TITLE
feat: add theme toggle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -9,6 +9,10 @@
   font-weight: 400;
   font-size: 20px;
 }
+body {
+  background: #fff;
+  color: #111;
+}
 input::-webkit-inner-spin-button,
 input::-webkit-outer-spin-button {
   -webkit-appearance: none;
@@ -137,6 +141,18 @@ input::-webkit-outer-spin-button {
 
 .navbar .links ul:last-child {
   gap: 10px;
+}
+
+.navbar .theme_toggle {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 24px;
+  color: #444;
+}
+.navbar .theme_toggle:hover {
+  color: #077edf;
+  transition: 0.3s;
 }
 
 @media (max-width: 1320px) {
@@ -1548,4 +1564,30 @@ button:disabled:hover {
   background: gray;
   cursor: not-allowed;
   color: #111;
+}
+
+body.dark {
+  background: #111;
+  color: #fff;
+}
+
+body.dark .navbar {
+  background: #111;
+  border-bottom: 1px solid #444;
+}
+
+body.dark .navbar .links ul li a {
+  color: #fff;
+}
+
+body.dark .navbar .links ul li a:hover {
+  color: #077edf;
+}
+
+body.dark .theme_toggle {
+  color: #fff;
+}
+
+body.dark .theme_toggle:hover {
+  color: #077edf;
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,10 +1,22 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { GiHamburgerMenu } from "react-icons/gi";
+import { FaSun, FaMoon } from "react-icons/fa";
 const Navbar = () => {
   const [show, setShow] = useState(false);
+  const [theme, setTheme] = useState(
+    localStorage.getItem("theme") || "light"
+  );
   const { isAuthenticated } = useSelector((state) => state.user);
+
+  useEffect(() => {
+    document.body.className = theme === "dark" ? "dark" : "";
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
   return (
     <>
       <nav className={show ? "navbar show_navbar" : "navbar"}>
@@ -38,6 +50,13 @@ const Navbar = () => {
             )}
           </ul>
         </div>
+        <button
+          className="theme_toggle"
+          onClick={toggleTheme}
+          aria-label="Toggle theme"
+        >
+          {theme === "light" ? <FaMoon /> : <FaSun />}
+        </button>
         <GiHamburgerMenu className="hamburger" onClick={() => setShow(!show)} />
       </nav>
     </>


### PR DESCRIPTION
## Summary
- add light/dark theme toggle to navbar with persisted preference
- style theme toggle button and provide dark theme styles

## Testing
- `cd backend && npm test` (fails: Missing script: "test")
- `cd ../frontend && npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)


------
https://chatgpt.com/codex/tasks/task_e_68ab0ee9a808833186aa4aae6535f0af