### PR TITLE
Add Jest test suite and configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": [
+    ["@babel/preset-env", {"targets": {"node": "current"}}],
+    "@babel/preset-react"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/__tests__/backend/cron.test.js
+++ b/__tests__/backend/cron.test.js
@@ -1,0 +1,22 @@
+import { newsLetterCron } from '../../backend/automation/newsLetterCron.js';
+import cron from 'node-cron';
+import { Job } from '../../backend/models/jobSchema.js';
+import { User } from '../../backend/models/userSchema.js';
+import { sendEmail } from '../../backend/utils/sendEmail.js';
+
+jest.mock('node-cron', () => ({ schedule: jest.fn((expr, fn) => fn()) }));
+jest.mock('../../backend/models/jobSchema.js', () => ({ Job: { find: jest.fn() } }));
+jest.mock('../../backend/models/userSchema.js', () => ({ User: { find: jest.fn() } }));
+jest.mock('../../backend/utils/sendEmail.js', () => ({ sendEmail: jest.fn() }));
+
+describe('newsLetterCron', () => {
+  it('sends emails to matching users and marks job', async () => {
+    const job = { jobNiche:'Tech', title:'Dev', companyName:'X', location:'NY', salary:'100', newsLettersSent:false, save: jest.fn() };
+    Job.find.mockResolvedValue([job]);
+    User.find.mockResolvedValue([{ name:'User', email:'u@test.com' }]);
+    newsLetterCron();
+    await Promise.resolve();
+    expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ email:'u@test.com' }));
+    expect(job.save).toHaveBeenCalled();
+  });
+});

--- a/__tests__/backend/jobController.test.js
+++ b/__tests__/backend/jobController.test.js
@@ -1,0 +1,30 @@
+import { postJob } from '../../backend/controllers/jobController.js';
+import ErrorHandler from '../../backend/middlewares/error.js';
+import { Job } from '../../backend/models/jobSchema.js';
+
+jest.mock('../../backend/models/jobSchema.js', () => ({ Job: { create: jest.fn(), find: jest.fn(), findById: jest.fn() } }));
+
+describe('postJob', () => {
+  it('errors if required fields missing', async () => {
+    const req = { body: {}, user: { _id: '1' } };
+    const next = jest.fn();
+    await postJob(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('errors if website fields mismatch', async () => {
+    const req = { body: { title:'t', jobType:'full', location:'loc', companyName:'comp', introduction:'intro', responsibilities:'res', qualifications:'qual', salary:'100', jobNiche:'tech', personalWebsiteTitle:'site' }, user:{ _id:'1' } };
+    const next = jest.fn();
+    await postJob(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('creates job successfully', async () => {
+    Job.create.mockResolvedValue({ title:'t' });
+    const req = { body: { title:'t', jobType:'full', location:'loc', companyName:'comp', introduction:'intro', responsibilities:'res', qualifications:'qual', salary:'100', jobNiche:'tech', personalWebsiteTitle:'site', personalWebsiteUrl:'url' }, user:{ _id:'1' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await postJob(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/__tests__/backend/middlewares.test.js
+++ b/__tests__/backend/middlewares.test.js
@@ -1,0 +1,71 @@
+import { isAuthenticated, isAuthorized } from '../../backend/middlewares/auth.js';
+import { catchAsyncErrors } from '../../backend/middlewares/catchAsyncErrors.js';
+import { errorMiddleware } from '../../backend/middlewares/error.js';
+import ErrorHandler from '../../backend/middlewares/error.js';
+import jwt from 'jsonwebtoken';
+import { User } from '../../backend/models/userSchema.js';
+
+jest.mock('jsonwebtoken', () => ({ verify: jest.fn() }));
+jest.mock('../../backend/models/userSchema.js', () => ({ User: { findById: jest.fn() } }));
+
+describe('isAuthenticated', () => {
+  it('throws error if token missing', async () => {
+    const req = { cookies: {} };
+    const next = jest.fn();
+    await isAuthenticated(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('attaches user when token valid', async () => {
+    const req = { cookies: { token: 'abc' } };
+    const next = jest.fn();
+    jwt.verify.mockReturnValue({ id: '1' });
+    User.findById.mockResolvedValue({ name: 'Test' });
+    await isAuthenticated(req, {}, next);
+    expect(req.user).toEqual({ name: 'Test' });
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('isAuthorized', () => {
+  it('blocks unauthorized role', () => {
+    const middleware = isAuthorized('Admin');
+    const req = { user: { role: 'User' } };
+    const next = jest.fn();
+    middleware(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('allows authorized role', () => {
+    const middleware = isAuthorized('Admin');
+    const req = { user: { role: 'Admin' } };
+    const next = jest.fn();
+    middleware(req, {}, next);
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('catchAsyncErrors', () => {
+  it('catches errors and passes to next', async () => {
+    const fn = catchAsyncErrors(async () => { throw new Error('fail'); });
+    const next = jest.fn();
+    await fn({}, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe('errorMiddleware', () => {
+  it('handles cast error', () => {
+    const err = { name: 'CastError', path: 'id' };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    errorMiddleware(err, {}, res, () => {});
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('handles default error', () => {
+    const err = { message: 'oops' };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    errorMiddleware(err, {}, res, () => {});
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+});

--- a/__tests__/backend/models.test.js
+++ b/__tests__/backend/models.test.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { User } from '../../backend/models/userSchema.js';
+
+describe('User model', () => {
+  let mongo;
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri());
+  });
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongo.stop();
+  });
+
+  it('hashes password and compares', async () => {
+    const user = await User.create({
+      name:'Test',
+      email:'t@t.com',
+      phone:1,
+      address:'addr',
+      password:'password123',
+      role:'Employer'
+    });
+    expect(user.password).not.toBe('password123');
+    const match = await user.comparePassword('password123');
+    expect(match).toBe(true);
+  });
+
+  it('generates jwt token', () => {
+    const user = new User({
+      name:'Test', email:'t2@t.com', phone:1, address:'addr', password:'password123', role:'Employer'
+    });
+    const token = user.getJWTToken();
+    expect(typeof token).toBe('string');
+  });
+});

--- a/__tests__/backend/userController.test.js
+++ b/__tests__/backend/userController.test.js
@@ -1,0 +1,94 @@
+import { register, login } from '../../backend/controllers/userController.js';
+import ErrorHandler from '../../backend/middlewares/error.js';
+import { User } from '../../backend/models/userSchema.js';
+import { sendToken } from '../../backend/utils/jwtToken.js';
+
+jest.mock('../../backend/models/userSchema.js', () => ({
+  User: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('../../backend/utils/jwtToken.js', () => ({
+  sendToken: jest.fn(),
+}));
+
+jest.mock('cloudinary', () => ({
+  v2: { uploader: { upload: jest.fn() } }
+}));
+
+describe('userController register', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns error when required fields missing', async () => {
+    const req = { body: { email: 'test@test.com' } };
+    const next = jest.fn();
+    await register(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('returns error when email exists', async () => {
+    User.findOne.mockResolvedValue({ _id: '1' });
+    const req = { body: { name:'A', email:'test@test.com', phone:1, address:'addr', password:'password123', role:'Employer' } };
+    const next = jest.fn();
+    await register(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('registers successfully', async () => {
+    User.findOne.mockResolvedValue(null);
+    User.create.mockResolvedValue({ getJWTToken: () => 'token' });
+    const req = { body: { name:'A', email:'test@test.com', phone:1, address:'addr', password:'password123', role:'Employer' } };
+    const res = { status: jest.fn().mockReturnThis(), cookie: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await register(req, res, next);
+    expect(sendToken).toHaveBeenCalled();
+  });
+});
+
+describe('userController login', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('errors for missing fields', async () => {
+    const req = { body: { email: 'a@a.com' } };
+    const next = jest.fn();
+    await login(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('errors for invalid email', async () => {
+    User.findOne.mockResolvedValue(null);
+    const req = { body: { role:'Employer', email:'a@a.com', password:'pass1234' } };
+    const next = jest.fn();
+    await login(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('errors for wrong password', async () => {
+    User.findOne.mockResolvedValue({ comparePassword: jest.fn().mockResolvedValue(false), role:'Employer' });
+    const req = { body: { role:'Employer', email:'a@a.com', password:'pass1234' } };
+    const next = jest.fn();
+    await login(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('errors for role mismatch', async () => {
+    User.findOne.mockResolvedValue({ comparePassword: jest.fn().mockResolvedValue(true), role:'Job Seeker' });
+    const req = { body: { role:'Employer', email:'a@a.com', password:'pass1234' } };
+    const next = jest.fn();
+    await login(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('logs in successfully', async () => {
+    User.findOne.mockResolvedValue({ comparePassword: jest.fn().mockResolvedValue(true), role:'Employer' });
+    const req = { body: { role:'Employer', email:'a@a.com', password:'pass1234' } };
+    const res = { status: jest.fn().mockReturnThis(), cookie: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await login(req, res, next);
+    expect(sendToken).toHaveBeenCalled();
+  });
+});

--- a/__tests__/backend/utils.test.js
+++ b/__tests__/backend/utils.test.js
@@ -1,0 +1,29 @@
+import { sendToken } from '../../backend/utils/jwtToken.js';
+import { sendEmail } from '../../backend/utils/sendEmail.js';
+import nodeMailer from 'nodemailer';
+
+jest.mock('nodemailer');
+
+describe('sendToken', () => {
+  it('sets cookie and returns token', () => {
+    const user = { getJWTToken: () => 'abc' };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    sendToken(user, 200, res, 'ok');
+    expect(res.cookie).toHaveBeenCalledWith('token', 'abc', expect.any(Object));
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ token: 'abc', message: 'ok' }));
+  });
+});
+
+describe('sendEmail', () => {
+  it('uses nodemailer transport', async () => {
+    const send = jest.fn().mockResolvedValue(true);
+    nodeMailer.createTransport.mockReturnValue({ sendMail: send });
+    await sendEmail({ email: 'a@a.com', subject: 'sub', message: 'msg' });
+    expect(nodeMailer.createTransport).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ to: 'a@a.com' }));
+  });
+});

--- a/__tests__/frontend/Hero.test.jsx
+++ b/__tests__/frontend/Hero.test.jsx
@@ -1,0 +1,11 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Hero from '../../frontend/src/components/Hero.jsx';
+
+describe('Hero component', () => {
+  it('renders heading', () => {
+    render(<Hero />);
+    expect(screen.getByText(/Find Your Dream Job Today/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/frontend/userSlice.test.js
+++ b/__tests__/frontend/userSlice.test.js
@@ -1,0 +1,20 @@
+import reducer, { register } from '../../frontend/src/store/slices/userSlice.js';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('userSlice reducers', () => {
+  it('handles registerRequest', () => {
+    const state = reducer(undefined, { type: 'user/registerRequest' });
+    expect(state.loading).toBe(true);
+  });
+});
+
+describe('userSlice register thunk', () => {
+  it('dispatches success on resolve', async () => {
+    axios.post.mockResolvedValue({ data: { user: { name:'A' }, message:'done' } });
+    const dispatch = jest.fn();
+    await register({})(dispatch);
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'user/registerSuccess' }));
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+export default {
+  transform: {
+    '^.+\\.[tj]sx?$': ['babel-jest']
+  },
+  testPathIgnorePatterns: ['/node_modules/'],
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  collectCoverageFrom: [
+    'backend/**/*.js',
+    'frontend/src/**/*.jsx',
+    'frontend/src/**/*.js',
+    '!backend/node_modules/**',
+    '!frontend/node_modules/**'
+  ]
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,10 @@
+import '@testing-library/jest-dom';
+
+process.env.JWT_SECRET_KEY = 'testsecret';
+process.env.JWT_EXPIRE = '1d';
+process.env.COOKIE_EXPIRE = '5';
+process.env.SMTP_HOST = 'smtp.test';
+process.env.SMTP_SERVICE = 'gmail';
+process.env.SMTP_PORT = '465';
+process.env.SMTP_MAIL = 'test@test.com';
+process.env.SMTP_PASSWORD = 'password';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jobscape-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "jest --runInBand --coverage"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@babel/preset-env": "^7.23.9",
+    "@babel/preset-react": "^7.23.3",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "axios": "^1.7.2",
+    "babel-jest": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "mongodb-memory-server": "^8.12.1",
+    "supertest": "^6.3.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest configuration and setup for project-wide testing
- implement unit tests for controllers, middlewares, utilities, models, cron job, React components, and Redux slices

## Testing
- `npm test` *(fails: jest not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae80b0e67c83319dd5a19d5ae422c9