### PR TITLE
Add ML-based job recommendation service and integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Sample environment variables for JobScape
+MONGO_URI=mongodb://localhost:27017/jobscape
+FRONTEND_URL=http://localhost:5173
+FRONTEND_URL_2=http://localhost:5174
+PORT=4000
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_API_KEY=your_api_key
+CLOUDINARY_API_SECRET=your_api_secret
+JWT_SECRET_KEY=supersecret
+JWT_EXPIRE=7d
+COOKIE_EXPIRE=7
+SMTP_HOST=smtp.example.com
+SMTP_SERVICE=gmail
+SMTP_PORT=587
+SMTP_MAIL=your_email@example.com
+SMTP_PASSWORD=your_password
+# URL of the Python ML microservice
+ML_SERVICE_URL=http://localhost:8001

--- a/__tests__/backend/recommendationController.test.js
+++ b/__tests__/backend/recommendationController.test.js
@@ -1,0 +1,31 @@
+import { recommendJobs, suggestSkills } from '../../backend/controllers/recommendationController.js';
+import ErrorHandler from '../../backend/middlewares/error.js';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('recommendationController', () => {
+  it('errors when resume missing', async () => {
+    const req = { body: {} };
+    const next = jest.fn();
+    await recommendJobs(req, {}, next);
+    expect(next).toHaveBeenCalledWith(expect.any(ErrorHandler));
+  });
+
+  it('returns recommendations', async () => {
+    axios.post.mockResolvedValue({ data: { recommendations: [] } });
+    const req = { body: { resume: 'test' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await recommendJobs(req, res, () => {});
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(axios.post).toHaveBeenCalled();
+  });
+
+  it('suggests skills', async () => {
+    axios.post.mockResolvedValue({ data: { missing_skills: ['python'] } });
+    const req = { body: { resume: 'hi', category: 'software' } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await suggestSkills(req, res, () => {});
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+});

--- a/__tests__/backend/recommendationRouter.test.js
+++ b/__tests__/backend/recommendationRouter.test.js
@@ -1,0 +1,34 @@
+import express from 'express';
+import request from 'supertest';
+import recommendationRouter from '../../backend/routes/recommendationRouter.js';
+import axios from 'axios';
+import { errorMiddleware } from '../../backend/middlewares/error.js';
+
+jest.mock('axios');
+jest.mock('../../backend/middlewares/auth.js', () => ({
+  isAuthenticated: (req, res, next) => {
+    req.user = { _id: '1' };
+    next();
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1', recommendationRouter);
+app.use(errorMiddleware);
+
+describe('recommendation routes', () => {
+  it('returns 200 for recommend', async () => {
+    axios.post.mockResolvedValue({ data: { recommendations: [] } });
+    const res = await request(app).post('/api/v1/recommend').send({ resume: 'abc' });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns error for failing suggestSkills', async () => {
+    axios.post.mockRejectedValue(new Error('fail'));
+    const res = await request(app)
+      .post('/api/v1/suggestSkills')
+      .send({ resume: 'abc', category: 'software' });
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,6 +8,7 @@ import fileUpload from "express-fileupload";
 import userRouter from "./routes/userRouter.js";
 import jobRouter from "./routes/jobRouter.js";
 import applicationRouter from "./routes/applicationRouter.js";
+import recommendationRouter from "./routes/recommendationRouter.js";
 import { newsLetterCron } from "./automation/newsLetterCron.js";
 
 
@@ -36,6 +37,7 @@ app.use(
 app.use("/api/v1/user", userRouter);
 app.use("/api/v1/job", jobRouter);
 app.use("/api/v1/application", applicationRouter);
+app.use("/api/v1", recommendationRouter);
 
 newsLetterCron()
 connection();

--- a/backend/controllers/recommendationController.js
+++ b/backend/controllers/recommendationController.js
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { catchAsyncErrors } from "../middlewares/catchAsyncErrors.js";
+import ErrorHandler from "../middlewares/error.js";
+
+const ML_URL = process.env.ML_SERVICE_URL || "http://localhost:8001";
+
+export const recommendJobs = catchAsyncErrors(async (req, res, next) => {
+  const { resume, topN } = req.body;
+  if (!resume) {
+    return next(new ErrorHandler("Resume text is required", 400));
+  }
+  const { data } = await axios.post(`${ML_URL}/recommend`, { resume, top_n: topN });
+  res.status(200).json({ success: true, recommendations: data.recommendations });
+});
+
+export const suggestSkills = catchAsyncErrors(async (req, res, next) => {
+  const { resume, category } = req.body;
+  if (!resume || !category) {
+    return next(new ErrorHandler("Resume text and category are required", 400));
+  }
+  const { data } = await axios.post(`${ML_URL}/suggestSkills`, { resume, category });
+  res
+    .status(200)
+    .json({ success: true, missingSkills: data.missing_skills });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "ml": "uvicorn ../ml_service.main:app --port 8001 --reload"
   },
   "author": "",
   "license": "ISC",

--- a/backend/routes/recommendationRouter.js
+++ b/backend/routes/recommendationRouter.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { isAuthenticated } from "../middlewares/auth.js";
+import { recommendJobs, suggestSkills } from "../controllers/recommendationController.js";
+
+const router = express.Router();
+
+router.post("/recommend", isAuthenticated, recommendJobs);
+router.post("/suggestSkills", isAuthenticated, suggestSkills);
+
+export default router;

--- a/frontend/src/components/RecommendedJobs.jsx
+++ b/frontend/src/components/RecommendedJobs.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchRecommendations, fetchSkillSuggestions, clearRecommendationErrors } from "../store/slices/recommendationSlice";
+import { toast } from "react-toastify";
+
+const RecommendedJobs = () => {
+  const [resume, setResume] = useState("");
+  const [category, setCategory] = useState("");
+  const dispatch = useDispatch();
+  const { recommendations, skills, loading, error } = useSelector(
+    (state) => state.recommendation
+  );
+
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+      dispatch(clearRecommendationErrors());
+    }
+  }, [error, dispatch]);
+
+  const handleRecommend = () => {
+    if (resume.trim()) {
+      dispatch(fetchRecommendations(resume));
+    }
+  };
+
+  const handleSkills = () => {
+    if (resume.trim() && category.trim()) {
+      dispatch(fetchSkillSuggestions(resume, category));
+    }
+  };
+
+  return (
+    <div className="recommended">
+      <h3>Get Job Recommendations</h3>
+      <textarea
+        value={resume}
+        onChange={(e) => setResume(e.target.value)}
+        placeholder="Paste your resume text here"
+        rows="6"
+      />
+      <button onClick={handleRecommend} disabled={loading}>
+        {loading ? "Loading..." : "Recommend"}
+      </button>
+      {recommendations && recommendations.length > 0 && (
+        <ul>
+          {recommendations.map((r, i) => (
+            <li key={i}>{`${r.title} - ${(r.score * 100).toFixed(1)}%`}</li>
+          ))}
+        </ul>
+      )}
+      <h4>Improve My Résumé</h4>
+      <input
+        type="text"
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        placeholder="Desired job category"
+      />
+      <button onClick={handleSkills} disabled={loading}>
+        {loading ? "Checking..." : "Suggest Skills"}
+      </button>
+      {skills && skills.length > 0 && (
+        <ul>
+          {skills.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default RecommendedJobs;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import MyJobs from "../components/MyJobs";
 import JobPost from "../components/JobPost";
 import Applications from "../components/Applications";
 import MyApplications from "../components/MyApplications";
+import RecommendedJobs from "../components/RecommendedJobs";
 
 const Dashboard = () => {
   const [show, setShow] = useState(false);
@@ -129,6 +130,18 @@ const Dashboard = () => {
                   </button>
                 </li>
               )}
+              {user && user.role === "Job Seeker" && (
+                <li>
+                  <button
+                    onClick={() => {
+                      setComponentName("Recommended Jobs");
+                      setShow(!show);
+                    }}
+                  >
+                    Recommended Jobs
+                  </button>
+                </li>
+              )}
               <li>
                 <button onClick={handleLogout}>Logout</button>
               </li>
@@ -167,6 +180,9 @@ const Dashboard = () => {
                   break;
                 case "My Applications":
                   return <MyApplications />;
+                  break;
+                case "Recommended Jobs":
+                  return <RecommendedJobs />;
                   break;
 
                 default:

--- a/frontend/src/store/slices/recommendationSlice.js
+++ b/frontend/src/store/slices/recommendationSlice.js
@@ -1,0 +1,75 @@
+import { createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
+
+const recommendationSlice = createSlice({
+  name: "recommendation",
+  initialState: {
+    recommendations: [],
+    skills: [],
+    loading: false,
+    error: null,
+  },
+  reducers: {
+    request(state) {
+      state.loading = true;
+      state.error = null;
+    },
+    recommendSuccess(state, action) {
+      state.loading = false;
+      state.recommendations = action.payload;
+    },
+    skillsSuccess(state, action) {
+      state.loading = false;
+      state.skills = action.payload;
+    },
+    failure(state, action) {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    clearErrors(state) {
+      state.error = null;
+    },
+  },
+});
+
+export const fetchRecommendations = (resume) => async (dispatch) => {
+  try {
+    dispatch(recommendationSlice.actions.request());
+    const { data } = await axios.post(
+      `http://localhost:4000/api/v1/recommend`,
+      { resume },
+      { withCredentials: true }
+    );
+    dispatch(recommendationSlice.actions.recommendSuccess(data.recommendations));
+  } catch (error) {
+    dispatch(
+      recommendationSlice.actions.failure(
+        error.response?.data?.message || error.message
+      )
+    );
+  }
+};
+
+export const fetchSkillSuggestions = (resume, category) => async (dispatch) => {
+  try {
+    dispatch(recommendationSlice.actions.request());
+    const { data } = await axios.post(
+      `http://localhost:4000/api/v1/suggestSkills`,
+      { resume, category },
+      { withCredentials: true }
+    );
+    dispatch(recommendationSlice.actions.skillsSuccess(data.missingSkills));
+  } catch (error) {
+    dispatch(
+      recommendationSlice.actions.failure(
+        error.response?.data?.message || error.message
+      )
+    );
+  }
+};
+
+export const clearRecommendationErrors = () => (dispatch) => {
+  dispatch(recommendationSlice.actions.clearErrors());
+};
+
+export default recommendationSlice.reducer;

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -3,13 +3,15 @@ import jobReducer from "./slices/jobSlice";
 import userReducer from "./slices/userSlice";
 import applicationReducer from "./slices/applicationSlice";
 import updateProfileReducer from "./slices/updateProfileSlice";
+import recommendationReducer from "./slices/recommendationSlice";
 
 const store = configureStore({
   reducer: {
     user: userReducer,
     jobs: jobReducer,
     applications: applicationReducer,
-    updateProfile: updateProfileReducer
+    updateProfile: updateProfileReducer,
+    recommendation: recommendationReducer
   },
 });
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,3 +8,4 @@ process.env.SMTP_SERVICE = 'gmail';
 process.env.SMTP_PORT = '465';
 process.env.SMTP_MAIL = 'test@test.com';
 process.env.SMTP_PASSWORD = 'password';
+process.env.ML_SERVICE_URL = 'http://localhost:8001';

--- a/ml_service/README.md
+++ b/ml_service/README.md
@@ -1,0 +1,25 @@
+# ML Service
+
+This FastAPI service powers the recommendation features of JobScape.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload --port 8001
+```
+
+## Endpoints
+
+- `POST /recommend` – accepts JSON with a `resume` field and returns the top
+  matching jobs from the MongoDB `jobs` collection.
+- `POST /suggestSkills` – returns a list of missing skills for a given resume
+  and desired job `category`.
+
+## Training
+
+The initial model uses TF‑IDF vectors and cosine similarity.  To retrain or
+extend the model, prepare a CSV file similar to `sample_data/training.csv` and
+update the preprocessing or vectorisation steps in `main.py`.  Replace or extend
+`skills_by_category` with categories relevant to your platform.
+

--- a/ml_service/main.py
+++ b/ml_service/main.py
@@ -1,0 +1,115 @@
+import os
+import re
+from typing import List, Optional
+
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from pydantic import BaseModel
+
+try:
+    import spacy
+    try:
+        nlp = spacy.load("en_core_web_sm")
+    except Exception:
+        nlp = spacy.blank("en")
+except Exception:  # pragma: no cover - spaCy is optional
+    spacy = None
+    nlp = None
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+# The service uses MongoDB to read job postings.
+# During tests this connection is not executed, but the code demonstrates
+# how to integrate with a running Mongo instance.
+from pymongo import MongoClient
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017/jobscape")
+client = MongoClient(MONGO_URI)
+db = client.get_default_database()
+jobs_collection = db["jobs"]
+
+app = FastAPI(title="JobScape ML Service")
+
+
+def _preprocess(text: str) -> str:
+    """Lower‑case and remove non alphanumeric characters."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    return text
+
+
+def _vectorize(docs: List[str]):
+    vectorizer = TfidfVectorizer(stop_words="english")
+    matrix = vectorizer.fit_transform(docs)
+    return matrix
+
+
+class RecommendRequest(BaseModel):
+    resume: str
+    top_n: Optional[int] = 5
+
+
+class RecommendResponseItem(BaseModel):
+    jobId: str
+    title: str
+    score: float
+
+
+class RecommendResponse(BaseModel):
+    recommendations: List[RecommendResponseItem]
+
+
+class SkillRequest(BaseModel):
+    resume: str
+    category: str
+
+
+class SkillResponse(BaseModel):
+    missing_skills: List[str]
+
+
+@app.post("/recommend", response_model=RecommendResponse)
+async def recommend(data: RecommendRequest):
+    """Return top N matching jobs based on cosine similarity."""
+    resume_text = _preprocess(data.resume)
+    jobs = list(jobs_collection.find({}, {"title": 1, "description": 1}))
+    if not jobs:
+        return {"recommendations": []}
+    docs = [resume_text] + [
+        _preprocess(j.get("description", "")) for j in jobs
+    ]
+    matrix = _vectorize(docs)
+    sims = cosine_similarity(matrix[0:1], matrix[1:]).flatten()
+    top_indices = sims.argsort()[::-1][: data.top_n]
+    recs = []
+    for idx in top_indices:
+        job = jobs[idx]
+        recs.append(
+            {
+                "jobId": str(job.get("_id")),
+                "title": job.get("title", ""),
+                "score": float(sims[idx]),
+            }
+        )
+    return {"recommendations": recs}
+
+
+@app.post("/suggestSkills", response_model=SkillResponse)
+async def suggest_skills(data: SkillRequest):
+    """Very small demo that compares the resume with a skills list."""
+    skills_by_category = {
+        "software": {"python", "javascript", "react", "node"},
+        "data": {"python", "sql", "pandas", "machine", "learning"},
+    }
+    required = skills_by_category.get(data.category.lower(), set())
+    tokens = set(_preprocess(data.resume).split())
+    missing = sorted(list(required - tokens))
+    return {"missing_skills": missing}
+
+
+@app.post("/upload", response_model=RecommendResponse)
+async def upload_resume(file: UploadFile = File(...), top_n: int = Form(5)):
+    content = await file.read()
+    text = content.decode("utf-8", errors="ignore")
+    req = RecommendRequest(resume=text, top_n=top_n)
+    return await recommend(req)

--- a/ml_service/requirements.txt
+++ b/ml_service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+scikit-learn
+spacy
+pymongo

--- a/ml_service/sample_data/training.csv
+++ b/ml_service/sample_data/training.csv
@@ -1,0 +1,4 @@
+text,category
+"Experienced software engineer skilled in Python and React",software
+"Data analyst with proficiency in SQL and machine learning",data
+"Marketing professional with SEO and content strategy experience",marketing


### PR DESCRIPTION
## Summary
- introduce FastAPI microservice that analyzes resumes, suggests skills and recommends jobs via TF‑IDF
- add Node controller/routes to call ML service and expose `/recommend` and `/suggestSkills`
- add React Redux slice and dashboard component for displaying recommendations
- document ML_SERVICE_URL in sample env file and add script to run ML service
- include unit tests for controller and routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ae890ce660833192021b7366f766ab