### PR TITLE
feat: enhance portal navigation and hero

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -83,8 +83,10 @@ input::-webkit-outer-spin-button {
   border-bottom: 1px solid rgb(133, 133, 133);
   padding: 20px 110px;
   align-items: center;
-  position: relative;  /* Added for proper stacking */
-  background: #fff;   /* Added to ensure content visibility */
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: #fff;
 }
 
 .navbar .hamburger {
@@ -492,7 +494,7 @@ footer div ul a span {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-width: 1700px;
+  width: 100%;
   max-width: 1700px;
   margin: 0 auto;
   gap: 50px;
@@ -523,6 +525,18 @@ footer div ul a span {
   transition: 0.3s;
   background: #111;
   color: #fff;
+}
+
+.hero-image {
+  width: 200px;
+  height: auto;
+}
+
+.hero .cta {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 @media (max-width: 1720px) {
   .hero {
@@ -835,10 +849,8 @@ footer div ul a span {
   border-bottom: 1px solid gray;
   margin-bottom: 20px;
 }
-.jobs .wrapper .filter-bar .cities div {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.jobs .wrapper .filter-bar .cities select {
+  padding: 4px 8px;
 }
 .jobs .search-tab-wrapper {
   display: flex;

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,8 +1,10 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 const Hero = () => {
   return (
     <section className="hero">
+      <img src="/jobscape.png" alt="job search" className="hero-image" />
       <h1>Find Your Dream Job Today</h1>
       <h4>
         Connecting Talent with Opportunities Across the Nation for Every Skill
@@ -13,6 +15,14 @@ const Hero = () => {
         you're a seasoned professional or just starting out, find the perfect
         role to advance your career. Our platform makes job searching easy and
         efficient, bringing you closer to your next big opportunity.
+      </div>
+      <div className="cta">
+        <Link to="/jobs" className="btn">
+          Start Searching Jobs
+        </Link>
+        <Link to="/dashboard" className="outline_btn">
+          Post a Job
+        </Link>
       </div>
     </section>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -42,11 +42,18 @@ const Navbar = () => {
                 </Link>
               </li>
             ) : (
-              <li>
-                <Link to={"/login"} onClick={() => setShow(!show)}>
-                  LOGIN
-                </Link>
-              </li>
+              <>
+                <li>
+                  <Link to={"/register"} onClick={() => setShow(!show)}>
+                    REGISTER
+                  </Link>
+                </li>
+                <li>
+                  <Link to={"/login"} onClick={() => setShow(!show)}>
+                    LOGIN
+                  </Link>
+                </li>
+              </>
             )}
           </ul>
         </div>

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -8,20 +8,16 @@ import { Link } from "react-router-dom";
 
 const Jobs = () => {
   const [city, setCity] = useState("");
-  const [selectedCity, setSelectedCity] = useState("");
   const [niche, setNiche] = useState("");
-  const [selectedNiche, setSelectedNiche] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
 
   const { jobs, loading, error } = useSelector((state) => state.jobs);
 
   const handleCityChange = (city) => {
     setCity(city);
-    setSelectedCity(city);
   };
   const handleNicheChange = (niche) => {
     setNiche(niche);
-    setSelectedNiche(niche);
   };
 
   const dispatch = useDispatch();
@@ -105,35 +101,29 @@ const Jobs = () => {
             <div className="filter-bar">
               <div className="cities">
                 <h2>Filter Job By City</h2>
-                {cities.map((city, index) => (
-                  <div key={index}>
-                    <input
-                      type="radio"
-                      id={city}
-                      name="city"
-                      value={city}
-                      checked={selectedCity === city}
-                      onChange={() => handleCityChange(city)}
-                      />
-                    <label htmlFor={city}>{city}</label>
-                  </div>
-                ))}
+                <select
+                  value={city}
+                  onChange={(e) => handleCityChange(e.target.value)}
+                >
+                  {cities.map((city, index) => (
+                    <option value={city} key={index}>
+                      {city}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div className="cities">
                 <h2>Filter Job By Niche</h2>
-                {nichesArray.map((niche, index) => (
-                  <div key={niche}>
-                    <input
-                      type="radio"
-                      id={niche}
-                      name="niche"
-                      value={niche}
-                      checked={selectedNiche === niche}
-                      onChange={() => handleNicheChange(niche)}
-                    />
-                    <label htmlFor={niche}>{niche}</label>
-                  </div>
-                ))}
+                <select
+                  value={niche}
+                  onChange={(e) => handleNicheChange(e.target.value)}
+                >
+                  {nichesArray.map((niche, index) => (
+                    <option value={niche} key={index}>
+                      {niche}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
             <div className="container">
@@ -159,7 +149,8 @@ const Jobs = () => {
                 </select>
               </div>
               <div className="jobs_container">
-                {jobs && jobs.length > 0 ? (jobs.map((element) => {
+                {jobs && jobs.length > 0 ? (
+                  jobs.map((element) => {
                     return (
                       <div className="card" key={element._id}>
                         {element.hiringMultipleCandidates === "Yes" ? (
@@ -189,16 +180,14 @@ const Jobs = () => {
                         </div>
                       </div>
                     );
-                  })) : (
-                  /************************************************************/
-                  /* BUG No.2 */
-                  <img src="./notfound.png" alt="job-not-found" style={{width: "100%"}}/>)
-                  /************************************************************/
-
-
-
-
-                  }
+                  })
+                ) : (
+                  <img
+                    src="/jobscape.png"
+                    alt="job-not-found"
+                    style={{ width: "100%" }}
+                  />
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add visual call-to-action hero with buttons
- include register link and sticky styling in navbar
- switch job filters to dropdowns and show fallback image when no jobs

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary' from '__tests__/backend/userController.test.js'; Jest failed to parse a file)*

------
https://chatgpt.com/codex/tasks/task_e_68af2387794083318b228e93da143e0c