### PR TITLE
feat(frontend): remove hero logo

### DIFF
--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -4,7 +4,6 @@ import { Link } from "react-router-dom";
 const Hero = () => {
   return (
     <section className="hero">
-      <img src="/jobscape.png" alt="job search" className="hero-image" />
       <h1>Find Your Dream Job Today</h1>
       <h4>
         Connecting Talent with Opportunities Across the Nation for Every Skill


### PR DESCRIPTION
## Summary
- remove JobScape logo from hero section to simplify landing page

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary'; Babel JSX config errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f211c7c8331bfca611990908a93