### PR TITLE
Lighten hero overlay for clearer homepage logo

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -502,7 +502,7 @@ footer div ul a span {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.3);
 }
 .hero .content {
   position: relative;


### PR DESCRIPTION
## Summary
- Reduce hero overlay darkness so the central logo stands out and balances with surrounding text

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', 'jsonwebtoken', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2833a58d083318c4fa8b0c5563482