### PR TITLE
Adjust homepage logo opacity

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -111,6 +111,7 @@ input::-webkit-outer-spin-button {
 .navbar .logo img {
   width: 250px;   /* Change to your desired width */
   height: auto;  /* Keeps aspect ratio */
+  opacity: 0.8;
 }
 
 .navbar .links {
@@ -169,6 +170,7 @@ input::-webkit-outer-spin-button {
   
   .navbar .logo img {
     width: 75px;
+    opacity: 0.8;
   }
 }
 
@@ -213,6 +215,7 @@ input::-webkit-outer-spin-button {
   .navbar .logo img {
     width: 150px;  /* Increased from 120px */
     height: auto;
+    opacity: 0.8;
   }
   
   .navbar .links {
@@ -259,6 +262,7 @@ input::-webkit-outer-spin-button {
     
     .navbar .logo img {
       width: 100px;  /* Increased from 75px */
+      opacity: 0.8;
     }
   }
   
@@ -311,6 +315,7 @@ input::-webkit-outer-spin-button {
     
     .navbar .logo img {
       width: 85px;  /* Increased from previous size */
+      opacity: 0.8;
     }
     
     header {
@@ -346,6 +351,7 @@ input::-webkit-outer-spin-button {
     
     .navbar .logo img {
       width: 60px;  /* Increased from 40px */
+      opacity: 0.8;
     }
     
     .navbar {


### PR DESCRIPTION
## Summary
- Reduce homepage logo transparency by applying consistent `opacity: 0.8` across logo image styles

## Testing
- `npm test` *(fails: missing modules and babel configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b288b0c1cc833183a7f200aa5fabd0