### PR TITLE
feat: add search endpoint for jobs

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -92,6 +92,19 @@ export const getAllJobs = catchAsyncErrors(async (req, res, next) => {
   });
 });
 
+export const searchJobs = catchAsyncErrors(async (req, res, next) => {
+  const { title, location } = req.query;
+  const query = {};
+  if (title) {
+    query.title = { $regex: title, $options: "i" };
+  }
+  if (location) {
+    query.location = { $regex: location, $options: "i" };
+  }
+  const jobs = await Job.find(query);
+  res.status(200).json({ success: true, jobs, count: jobs.length });
+});
+
 export const getMyJobs = catchAsyncErrors(async (req, res, next) => {
   const myJobs = await Job.find({ postedBy: req.user._id });
   res.status(200).json({

--- a/backend/routes/jobRouter.js
+++ b/backend/routes/jobRouter.js
@@ -1,11 +1,19 @@
 import express from "express";
 import { isAuthenticated, isAuthorized } from "../middlewares/auth.js";
-import { postJob, getAllJobs, getASingleJob, getMyJobs, deleteJob } from "../controllers/jobController.js";
+import {
+  postJob,
+  getAllJobs,
+  getASingleJob,
+  getMyJobs,
+  deleteJob,
+  searchJobs,
+} from "../controllers/jobController.js";
 
 const router = express.Router();
 
 router.post("/post", isAuthenticated, isAuthorized("Employer"), postJob);
 router.get("/getall", getAllJobs);
+router.get("/search", searchJobs);
 router.get("/getmyjobs", isAuthenticated, isAuthorized("Employer"), getMyJobs);
 router.delete("/delete/:id", isAuthenticated, isAuthorized("Employer"), deleteJob);
 router.get("/get/:id", getASingleJob)


### PR DESCRIPTION
## Summary
- add dedicated job search controller and route to support searching by title and location

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b291ee7cec8331879608b33fee1eff