### PR TITLE
feat: configure API base URL via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ MONGO_URI=mongodb://localhost:27017/jobscape
 FRONTEND_URL=http://localhost:5173
 FRONTEND_URL_2=http://localhost:5174
 PORT=4000
+BACKEND_URL=http://localhost:4000/api/v1
 CLOUDINARY_CLOUD_NAME=your_cloud_name
 CLOUDINARY_API_KEY=your_api_key
 CLOUDINARY_API_SECRET=your_api_secret

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000/api/v1

--- a/frontend/src/store/slices/applicationSlice.js
+++ b/frontend/src/store/slices/applicationSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
+const server = import.meta.env.VITE_API_URL;
+
 const applicationSlice = createSlice({
   name: "applications",
   initialState: {
@@ -84,7 +86,7 @@ export const fetchEmployerApplications = () => async (dispatch) => {
   dispatch(applicationSlice.actions.requestForAllApplications());
   try {
     const response = await axios.get(
-      `http://localhost:4000/api/v1/application/employer/getall`,
+      `${server}/application/employer/getall`,
       {
         withCredentials: true,
       }
@@ -108,7 +110,7 @@ export const fetchJobSeekerApplications = () => async (dispatch) => {
   dispatch(applicationSlice.actions.requestForMyApplications());
   try {
     const response = await axios.get(
-      `http://localhost:4000/api/v1/application/jobseeker/getall`,
+      `${server}/application/jobseeker/getall`,
       {
         withCredentials: true,
       }
@@ -132,7 +134,7 @@ export const postApplication = (data, jobId) => async (dispatch) => {
   dispatch(applicationSlice.actions.requestForPostApplication());
   try {
     const response = await axios.post(
-      `http://localhost:4000/api/v1/application/post/${jobId}`,
+      `${server}/application/post/${jobId}`,
       data,
       {
         withCredentials: true,
@@ -156,7 +158,7 @@ export const deleteApplication = (id) => async (dispatch) => {
   dispatch(applicationSlice.actions.requestForDeleteApplication());
   try {
     const response = await axios.delete(
-      `http://localhost:4000/api/v1/application/delete/${id}`,
+      `${server}/application/delete/${id}`,
       { withCredentials: true }
     );
     dispatch(

--- a/frontend/src/store/slices/jobSlice.js
+++ b/frontend/src/store/slices/jobSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
+const server = import.meta.env.VITE_API_URL;
+
 const jobSlice = createSlice({
   name: "jobs",
   initialState: {
@@ -108,7 +110,7 @@ export const fetchJobs =
   async (dispatch) => {
     try {
       dispatch(jobSlice.actions.requestForAllJobs());
-      let link = "http://localhost:4000/api/v1/job/getall?";
+      let link = `${server}/job/getall?`;
       let queryParams = [];
       if (searchKeyword) {
         queryParams.push(`searchKeyword=${searchKeyword}`);
@@ -157,7 +159,7 @@ export const fetchSingleJob = (jobId) => async (dispatch) => {
   dispatch(jobSlice.actions.requestForSingleJob());
   try {
     const response = await axios.get(
-      `http://localhost:4000/api/v1/job/get/${jobId}`,
+      `${server}/job/get/${jobId}`,
       { withCredentials: true }
     );
     dispatch(jobSlice.actions.successForSingleJob(response.data.job));
@@ -171,7 +173,7 @@ export const postJob = (data) => async (dispatch) => {
   dispatch(jobSlice.actions.requestForPostJob());
   try {
     const response = await axios.post(
-      `http://localhost:4000/api/v1/job/post`,
+      `${server}/job/post`,
       data,
       { withCredentials: true, headers: { "Content-Type": "application/json" } }
     );
@@ -186,7 +188,7 @@ export const getMyJobs = () => async (dispatch) => {
   dispatch(jobSlice.actions.requestForMyJobs());
   try {
     const response = await axios.get(
-      `http://localhost:4000/api/v1/job/getmyjobs`,
+      `${server}/job/getmyjobs`,
       { withCredentials: true }
     );
     dispatch(jobSlice.actions.successForMyJobs(response.data.myJobs));
@@ -200,7 +202,7 @@ export const deleteJob = (id) => async (dispatch) => {
   dispatch(jobSlice.actions.requestForDeleteJob());
   try {
     const response = await axios.delete(
-      `http://localhost:4000/api/v1/job/delete/${id}`,
+      `${server}/job/delete/${id}`,
       { withCredentials: true }
     );
     dispatch(jobSlice.actions.successForDeleteJob(response.data.message));

--- a/frontend/src/store/slices/recommendationSlice.js
+++ b/frontend/src/store/slices/recommendationSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
+const server = import.meta.env.VITE_API_URL;
+
 const recommendationSlice = createSlice({
   name: "recommendation",
   initialState: {
@@ -36,7 +38,7 @@ export const fetchRecommendations = (resume) => async (dispatch) => {
   try {
     dispatch(recommendationSlice.actions.request());
     const { data } = await axios.post(
-      `http://localhost:4000/api/v1/recommend`,
+      `${server}/recommend`,
       { resume },
       { withCredentials: true }
     );
@@ -54,7 +56,7 @@ export const fetchSkillSuggestions = (resume, category) => async (dispatch) => {
   try {
     dispatch(recommendationSlice.actions.request());
     const { data } = await axios.post(
-      `http://localhost:4000/api/v1/suggestSkills`,
+      `${server}/suggestSkills`,
       { resume, category },
       { withCredentials: true }
     );

--- a/frontend/src/store/slices/updateProfileSlice.js
+++ b/frontend/src/store/slices/updateProfileSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
+const server = import.meta.env.VITE_API_URL;
+
 const updateProfileSlice = createSlice({
   name: "updateProfile",
   initialState: {
@@ -47,7 +49,7 @@ export const updateProfile = (data) => async (dispatch) => {
   dispatch(updateProfileSlice.actions.updateProfileRequest());
   try {
     const response = await axios.put(
-      "http://localhost:4000/api/v1/user/update/profile",
+      `${server}/user/update/profile`,
       data,
       {
         withCredentials: true,
@@ -67,7 +69,7 @@ export const updatePassword = (data) => async (dispatch) => {
   dispatch(updateProfileSlice.actions.updatePasswordRequest());
   try {
     const response = await axios.put(
-      "http://localhost:4000/api/v1/user/update/password",
+      `${server}/user/update/password`,
       data,
       {
         withCredentials: true,

--- a/frontend/src/store/slices/userSlice.js
+++ b/frontend/src/store/slices/userSlice.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 
+const server = import.meta.env.VITE_API_URL;
+
 const userSlice = createSlice({
   name: "user",
   initialState: {
@@ -89,7 +91,7 @@ export const register = (data) => async (dispatch) => {
   dispatch(userSlice.actions.registerRequest());
   try {
     const response = await axios.post(
-      "http://localhost:4000/api/v1/user/register",
+      `${server}/user/register`,
       data,
       {
         withCredentials: true,
@@ -107,7 +109,7 @@ export const login = (data) => async (dispatch) => {
   dispatch(userSlice.actions.loginRequest());
   try {
     const response = await axios.post(
-      "http://localhost:4000/api/v1/user/login",
+      `${server}/user/login`,
       data,
       {
         withCredentials: true,
@@ -124,12 +126,9 @@ export const login = (data) => async (dispatch) => {
 export const getUser = () => async (dispatch) => {
   dispatch(userSlice.actions.fetchUserRequest());
   try {
-    const response = await axios.get(
-      "http://localhost:4000/api/v1/user/getuser",
-      {
-        withCredentials: true,
-      }
-    );
+    const response = await axios.get(`${server}/user/getuser`, {
+      withCredentials: true,
+    });
     dispatch(userSlice.actions.fetchUserSuccess(response.data.user));
     dispatch(userSlice.actions.clearAllErrors());
   } catch (error) {
@@ -138,12 +137,9 @@ export const getUser = () => async (dispatch) => {
 };
 export const logout = () => async (dispatch) => {
   try {
-    await axios.get(
-      "http://localhost:4000/api/v1/user/logout",
-      {
-        withCredentials: true,
-      }
-    );
+    await axios.get(`${server}/user/logout`, {
+      withCredentials: true,
+    });
     dispatch(userSlice.actions.logoutSuccess());
     dispatch(userSlice.actions.clearAllErrors());
   } catch (error) {


### PR DESCRIPTION
## Summary
- add backend and frontend environment samples for API URL
- use Vite environment variable for API requests across slices

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b294e26004833194ceff7cf96cf17e