### PR TITLE
centralize API base URL with helper

### DIFF
--- a/frontend/src/store/slices/applicationSlice.js
+++ b/frontend/src/store/slices/applicationSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import apiUrl from "../../utils/api";
 
-const server = import.meta.env.VITE_API_URL;
+const server = apiUrl;
 
 const applicationSlice = createSlice({
   name: "applications",

--- a/frontend/src/store/slices/jobSlice.js
+++ b/frontend/src/store/slices/jobSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import apiUrl from "../../utils/api";
 
-const server = import.meta.env.VITE_API_URL;
+const server = apiUrl;
 
 const jobSlice = createSlice({
   name: "jobs",

--- a/frontend/src/store/slices/recommendationSlice.js
+++ b/frontend/src/store/slices/recommendationSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import apiUrl from "../../utils/api";
 
-const server = import.meta.env.VITE_API_URL;
+const server = apiUrl;
 
 const recommendationSlice = createSlice({
   name: "recommendation",

--- a/frontend/src/store/slices/updateProfileSlice.js
+++ b/frontend/src/store/slices/updateProfileSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import apiUrl from "../../utils/api";
 
-const server = import.meta.env.VITE_API_URL;
+const server = apiUrl;
 
 const updateProfileSlice = createSlice({
   name: "updateProfile",

--- a/frontend/src/store/slices/userSlice.js
+++ b/frontend/src/store/slices/userSlice.js
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
+import apiUrl from "../../utils/api";
 
-const server = import.meta.env.VITE_API_URL;
+const server = apiUrl;
 
 const userSlice = createSlice({
   name: "user",

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,10 @@
+const apiUrl = import.meta?.env?.VITE_API_URL || process.env.VITE_API_URL;
+
+if (!apiUrl) {
+  const message =
+    "VITE_API_URL is not defined. Please set VITE_API_URL in your environment.";
+  console.warn(message);
+  throw new Error(message);
+}
+
+export default apiUrl;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,3 +9,4 @@ process.env.SMTP_PORT = '465';
 process.env.SMTP_MAIL = 'test@test.com';
 process.env.SMTP_PASSWORD = 'password';
 process.env.ML_SERVICE_URL = 'http://localhost:8001';
+process.env.VITE_API_URL = 'http://localhost:5000';


### PR DESCRIPTION
## Summary
- add API URL helper that throws when VITE_API_URL is missing
- update slices to source API URL from new helper
- configure test setup with fallback API URL

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b298441a7c8331bdd14f4a70ea2f85