### PR TITLE
feat: reveal jobs page hero text

### DIFF
--- a/__tests__/frontend/Jobs.test.jsx
+++ b/__tests__/frontend/Jobs.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Jobs from '../../frontend/src/pages/Jobs.jsx';
+import * as redux from 'react-redux';
+
+jest.mock('react-redux');
+
+const mockDispatch = jest.fn();
+
+beforeEach(() => {
+  redux.useDispatch.mockReturnValue(mockDispatch);
+  redux.useSelector.mockImplementation(selector => selector({ jobs: { jobs: [], loading: false, error: null } }));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders job page hero text', () => {
+  render(<Jobs />);
+  expect(screen.getByText(/Find Your Dream Job/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(/Discover opportunities that match your skills and aspirations/i)
+  ).toBeInTheDocument();
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -850,8 +850,20 @@ footer div ul a span {
 }
 
 .jobs {
-  padding: 40px 100px;
+  padding: 120px 100px 40px;
   min-height: 800px;
+}
+.jobs .jobs-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+.jobs .jobs-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+.jobs .jobs-header p {
+  margin-top: 10px;
 }
 .jobs .wrapper {
   display: flex;
@@ -1005,7 +1017,7 @@ footer div ul a span {
 
 @media (max-width: 920px) {
   .jobs {
-    padding: 40px 20px;
+    padding: 120px 20px 40px;
   }
   .jobs .search-tab-wrapper {
     width: 100%;

--- a/frontend/src/pages/Jobs.jsx
+++ b/frontend/src/pages/Jobs.jsx
@@ -88,6 +88,10 @@ const Jobs = () => {
         <Spinner />
       ) : (
         <section className="jobs">
+          <div className="jobs-header">
+            <h1>Find Your Dream Job</h1>
+            <p>Discover opportunities that match your skills and aspirations</p>
+          </div>
           <div className="search-tab-wrapper">
             <input
               type="text"


### PR DESCRIPTION
## Summary
- display job search hero text before filters
- prevent navbar overlap with responsive padding
- test jobs page hero heading renders

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary')*

------
https://chatgpt.com/codex/tasks/task_e_68b2d7a81dfc8331a2b4c1bc170e7194