### PR TITLE
fix: adjust jobs page spacing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1442,7 +1442,7 @@ p {
 
 /* Jobs Page Styles */
 .jobs-page {
-  padding: 2rem 0;
+  padding: 6rem 0 2rem;
   min-height: 100vh;
   background: var(--bg-primary);
 }


### PR DESCRIPTION
## Summary
- prevent jobs page header from overlapping with site navbar

## Testing
- `npm test` *(fails: Cannot find module 'cloudinary'; other modules missing)*
- `cd frontend && npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a02eca48331915f17b3fcb94c80