### PR TITLE
Fix dark/light theme toggle across pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
@@ -14,13 +14,15 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { useDispatch } from "react-redux";
 import { getUser } from "./store/slices/userSlice";
+import { useTheme } from "./context/ThemeContext.jsx";
 
 const App = () => {
   const dispatch = useDispatch();
+  const { theme } = useTheme();
 
   useEffect(() => {
     dispatch(getUser());
-  }, []);
+  }, [dispatch]);
 
   return (
     <>
@@ -39,7 +41,7 @@ const App = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
         <Footer />
-        <ToastContainer position="top-right" theme="dark" />
+        <ToastContainer position="top-right" theme={theme} />
       </Router>
     </>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,23 +1,16 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { FaSun, FaMoon, FaUserCircle } from "react-icons/fa";
-import { RiLogoutCircleRLine } from "react-icons/ri";
+import { useTheme } from "../context/ThemeContext.jsx";
 
 const Navbar = () => {
   const [show, setShow] = useState(false);
-  const [theme, setTheme] = useState(
-    localStorage.getItem("theme") || "dark"
-  );
+  const { theme, toggleTheme } = useTheme();
   const [scrolled, setScrolled] = useState(false);
   const { isAuthenticated, user } = useSelector((state) => state.user);
   const location = useLocation();
-
-  useEffect(() => {
-    document.body.classList.toggle("light", theme === "light");
-    localStorage.setItem("theme", theme);
-  }, [theme]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -28,9 +21,6 @@ const Navbar = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
-
-  const toggleTheme = () =>
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
 
   const isActiveLink = (path) => {
     return location.pathname === path;
@@ -46,12 +36,12 @@ const Navbar = () => {
               <span className="logo-text">JobScape</span>
             </Link>
           </div>
-          
+
           <div className="nav-links">
             <ul>
               <li>
-                <Link 
-                  to="/" 
+                <Link
+                  to="/"
                   className={`nav-link ${isActiveLink('/') ? 'active' : ''}`}
                   onClick={() => setShow(false)}
                 >
@@ -59,8 +49,8 @@ const Navbar = () => {
                 </Link>
               </li>
               <li>
-                <Link 
-                  to="/jobs" 
+                <Link
+                  to="/jobs"
                   className={`nav-link ${isActiveLink('/jobs') ? 'active' : ''}`}
                   onClick={() => setShow(false)}
                 >
@@ -70,8 +60,8 @@ const Navbar = () => {
               {isAuthenticated ? (
                 <>
                   <li>
-                    <Link 
-                      to="/dashboard" 
+                    <Link
+                      to="/dashboard"
                       className={`nav-link ${isActiveLink('/dashboard') ? 'active' : ''}`}
                       onClick={() => setShow(false)}
                     >
@@ -90,8 +80,8 @@ const Navbar = () => {
               ) : (
                 <>
                   <li>
-                    <Link 
-                      to="/register" 
+                    <Link
+                      to="/register"
                       className={`nav-link ${isActiveLink('/register') ? 'active' : ''}`}
                       onClick={() => setShow(false)}
                     >
@@ -99,8 +89,8 @@ const Navbar = () => {
                     </Link>
                   </li>
                   <li>
-                    <Link 
-                      to="/login" 
+                    <Link
+                      to="/login"
                       className={`nav-link ${isActiveLink('/login') ? 'active' : ''}`}
                       onClick={() => setShow(false)}
                     >
@@ -111,7 +101,8 @@ const Navbar = () => {
               )}
             </ul>
           </div>
-          
+
+  
           <div className="nav-actions">
             <button
               className="theme-toggle"
@@ -120,7 +111,7 @@ const Navbar = () => {
             >
               {theme === "light" ? <FaMoon /> : <FaSun />}
             </button>
-            
+
             <button
               className="hamburger"
               onClick={() => setShow(!show)}

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable react-refresh/only-export-components */
+/* eslint-disable react/prop-types */
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => localStorage.getItem("theme") || "dark");
+
+  useEffect(() => {
+    const body = document.body;
+    body.classList.remove("light", "dark");
+    body.classList.add(theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,11 +1,13 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-import {Provider} from "react-redux"
+import { Provider } from "react-redux"
 import store from "./store/store.js"
+import { ThemeProvider } from "./context/ThemeContext.jsx"
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <Provider store={store}>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </Provider>,
 )


### PR DESCRIPTION
## Summary
- centralize theme state in new ThemeContext with body class and localStorage sync
- wrap app with ThemeProvider and expose toggle to Navbar
- apply current theme to ToastContainer for consistent styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 67 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b351b707708331a5016faa2e28dd9e