### PR TITLE
Remove demo login options from login page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2333,77 +2333,6 @@ p {
   font-weight: 600;
 }
 
-/* Demo Buttons */
-.demo-buttons {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.btn-demo {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--border-color);
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border-radius: var(--radius);
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--transition);
-  text-align: center;
-  justify-content: center;
-}
-
-.btn-demo:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow);
-}
-
-.btn-demo.employer:hover {
-  border-color: var(--primary);
-  background: rgba(99, 102, 241, 0.1);
-}
-
-.btn-demo.seeker:hover {
-  border-color: var(--accent);
-  background: rgba(249, 115, 22, 0.1);
-}
-
-.btn-demo:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-}
-
-/* Divider */
-.divider {
-  position: relative;
-  text-align: center;
-  margin: 2rem 0;
-}
-
-.divider::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--border-color);
-}
-
-.divider span {
-  background: var(--bg-card);
-  padding: 0 1rem;
-  color: var(--text-muted);
-  position: relative;
-  z-index: 1;
-  font-size: 0.9rem;
-}
-
 /* Form Options */
 .form-options {
   display: flex;
@@ -2505,10 +2434,6 @@ p {
 
 /* Responsive Design for Login */
 @media (max-width: 768px) {
-  .demo-buttons {
-    grid-template-columns: 1fr;
-  }
-  
   .form-options {
     flex-direction: column;
     gap: 1rem;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -74,21 +74,6 @@ const Login = () => {
     }
   }, [dispatch, error, isAuthenticated, navigateTo]);
 
-  const handleDemoLogin = (userType) => {
-    setRole(userType);
-    setEmail(userType === "Employer" ? "demo.employer@jobscape.com" : "demo.seeker@jobscape.com");
-    setPassword("demopassword123");
-    
-    // Auto-submit after a short delay to show the filled form
-    setTimeout(() => {
-      const formData = new FormData();
-      formData.append("role", userType);
-      formData.append("email", userType === "Employer" ? "demo.employer@jobscape.com" : "demo.seeker@jobscape.com");
-      formData.append("password", "demopassword123");
-      dispatch(login(formData));
-    }, 1000);
-  };
-
   return (
     <section className="auth-page">
       <div className="auth-container">
@@ -98,32 +83,6 @@ const Login = () => {
             <h1>Welcome Back</h1>
           </div>
           <p>Sign in to your JobScape account</p>
-        </div>
-
-        {/* Demo Login Buttons */}
-        <div className="demo-buttons">
-          <button
-            type="button"
-            className="btn btn-demo employer"
-            onClick={() => handleDemoLogin("Employer")}
-            disabled={loading}
-          >
-            <FaUser />
-            Demo Employer Login
-          </button>
-          <button
-            type="button"
-            className="btn btn-demo seeker"
-            onClick={() => handleDemoLogin("Job Seeker")}
-            disabled={loading}
-          >
-            <FaUser />
-            Demo Job Seeker Login
-          </button>
-        </div>
-
-        <div className="divider">
-          <span>Or sign in manually</span>
         </div>
 
         <form className="auth-form" onSubmit={handleLogin}>


### PR DESCRIPTION
## Summary
- remove demo login buttons and handler from login screen
- drop unused demo/divider styles

## Testing
- `npm run lint` *(fails: context.getSource is not a function)*
- `npm test` *(fails: Cannot find module 'cloudinary'; Cannot find module 'jsonwebtoken')*

------
https://chatgpt.com/codex/tasks/task_e_68b3b470d9808331bd25ee0d6a0121b9