### PR TITLE
Style job application page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,6 +31,7 @@
   --radius: 0.5rem;
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
+  --radius-full: 9999px;
   
   --transition: all 0.3s ease;
 }
@@ -1812,6 +1813,215 @@ p {
   flex: 1;
   text-align: center;
   justify-content: center;
+}
+
+.application_page {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  align-items: flex-start;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 6rem 1.5rem 3rem;
+}
+
+.application_page form,
+.application_page .job-details {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: 2rem;
+}
+
+.application_page form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.application_page form h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  color: var(--text-primary);
+}
+
+.application_page form > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.application_page form label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.application_page form input,
+.application_page form textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  transition: var(--transition);
+}
+
+.application_page form input:focus,
+.application_page form textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.application_page form textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.application_page form button.btn {
+  margin-left: auto;
+  min-width: 150px;
+}
+
+.application_page .job-details header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.application_page .job-details header a {
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+.application_page .job-details header a:hover {
+  color: var(--primary-hover);
+  text-decoration: underline;
+}
+
+.application_page .job-details header p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.application_page .job-details hr {
+  border: none;
+  height: 1px;
+  background: var(--border-color);
+  margin: 2rem 0;
+}
+
+.application_page .job-details section {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.application_page .job-details .wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.application_page .job-details .wrapper h3,
+.application_page .job-details .wrapper h4 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.application_page .job-details .wrapper > div {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+}
+
+.application_page .job-details .wrapper > div svg {
+  font-size: 1.4rem;
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+.application_page .job-details .wrapper > div span:first-child {
+  display: block;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.application_page .job-details .location-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.application_page .job-details .location-wrapper svg {
+  font-size: 1.4rem;
+  color: var(--primary);
+}
+
+.application_page .job-details p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.application_page .job-details ul {
+  margin: 0.5rem 0 0 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.application_page .job-details footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.application_page .job-details footer h3 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.application_page .job-details footer p {
+  margin: 0;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .application_page {
+    grid-template-columns: 1fr;
+    padding: 6rem 1.25rem 3rem;
+  }
+
+  .application_page form button.btn {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .application_page {
+    padding: 6rem 1rem 2.5rem;
+  }
+
+  .application_page form,
+  .application_page .job-details {
+    padding: 1.5rem;
+  }
 }
 
 /* No Jobs Found */


### PR DESCRIPTION
## Summary
- add a reusable `--radius-full` design token to the CSS variables
- redesign the job application view so the form and job details share a consistent card layout with responsive spacing

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js which is not present in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc3ffaa6483319199c363b8706d98