### PR TITLE
Fix job details card layout width

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1832,6 +1832,9 @@ p {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
   padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .application_page form {
@@ -1920,12 +1923,14 @@ p {
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  width: 100%;
 }
 
 .application_page .job-details .wrapper {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  width: 100%;
 }
 
 .application_page .job-details .wrapper h3,
@@ -1933,6 +1938,7 @@ p {
   margin: 0;
   color: var(--text-primary);
 }
+
 
 .application_page .job-details .wrapper > div {
   display: flex;
@@ -1942,6 +1948,22 @@ p {
   background: var(--bg-tertiary);
   border-radius: var(--radius);
   border: 1px solid var(--border-color);
+  width: 100%;
+}
+
+.application_page .job-details .wrapper > div > div {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.application_page .job-details .wrapper > div span:last-child {
+  color: var(--text-primary);
+  font-weight: 600;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .application_page .job-details .wrapper > div svg {
@@ -1965,6 +1987,14 @@ p {
   border-radius: var(--radius);
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
+  width: 100%;
+}
+
+.application_page .job-details .location-wrapper span {
+  flex: 1;
+  color: var(--text-primary);
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .application_page .job-details .location-wrapper svg {
@@ -1975,6 +2005,7 @@ p {
 .application_page .job-details p {
   color: var(--text-secondary);
   line-height: 1.7;
+  word-break: break-word;
 }
 
 .application_page .job-details ul {
@@ -1982,6 +2013,7 @@ p {
   display: grid;
   gap: 0.5rem;
   color: var(--text-secondary);
+  word-break: break-word;
 }
 
 .application_page .job-details footer {


### PR DESCRIPTION
## Summary
- make the application page job details panel use a flex column layout instead of inheriting the global grid styles
- expand the detail rows and location banner to occupy the full card width and add wrapping for long values

## Testing
- node node_modules/vite/bin/vite.js build

------
https://chatgpt.com/codex/tasks/task_e_68cfdccc88888331a351e9e57d7f8222